### PR TITLE
Update link for deep contextual bandits code

### DIFF
--- a/_posts/2020-03-20-DRL-1.md
+++ b/_posts/2020-03-20-DRL-1.md
@@ -13,7 +13,7 @@ mathjax: true
 
 ### Abstract
 
-In this post I go through parts of the [original code](https://github.com/tensorflow/models/tree/master/research/deep_contextual_bandits) and link it to theory and intuition in some detail. I use this exercise to partition out a part of the code and partially reproduce the results from the article. Along the way I augmenting those results with auxilary findings and visualisations to aid understanding.
+In this post I go through parts of the [original code](https://github.com/tensorflow/models/tree/archive/research/deep_contextual_bandits) and link it to theory and intuition in some detail. I use this exercise to partition out a part of the code and partially reproduce the results from the article. Along the way I augmenting those results with auxilary findings and visualisations to aid understanding.
 
 #### Prerequisites
 


### PR DESCRIPTION
The current link seems to be deprecated. The PR will update it to an archived one.

By the way, nice blog, learnt a bunch of new stuff going through some of the articles.